### PR TITLE
Fix: Remove resource_owner_id in access token generation for compatibility with Doorkeeper 5.3.3+

### DIFF
--- a/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
+++ b/lib/doorkeeper/device_authorization_grant/oauth/device_code_request.rb
@@ -55,7 +55,7 @@ module Doorkeeper
         def generate_access_token_with_empty_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant.resource_owner_id,
+            device_grant,
             device_grant.scopes,
             {},
             server
@@ -65,7 +65,7 @@ module Doorkeeper
         def generate_access_token_without_custom_attributes
           find_or_create_access_token(
             device_grant.application,
-            device_grant.resource_owner_id,
+            device_grant,
             device_grant.scopes,
             server
           )


### PR DESCRIPTION
This PR removes the resource_owner_id method during access token generation to ensure compatibility with Doorkeeper 5.3.3+. This change addresses an issue introduced in newer versions of Doorkeeper where the resource_owner_id was no longer required in the token generation process.

This fix ensures that the doorkeeper-device_authorization_grant gem works seamlessly with the latest Doorkeeper versions.